### PR TITLE
fix: CalendarWidget 컴포넌트의 날짜 비교 로직 개선 및 키 값 수정

### DIFF
--- a/components/CalendarWidget.tsx
+++ b/components/CalendarWidget.tsx
@@ -24,10 +24,13 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
     return date.getDay() === 1;
   };
 
-  // 오늘인지 확인하는 함수
-  const isToday = (date: Date) => {
-    return date.toDateString() === today.toDateString();
-  };
+  // 오늘인지 확인하는 함수 (연/월/일 단위로 비교)
+  const isSameYMD = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+
+  const isToday = (date: Date) => isSameYMD(date, today);
 
   // 해당 날짜에 일반 점호가 있는지 확인하는 함수
   const hasRegularRollCall = (date: Date) => {
@@ -72,7 +75,7 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
     // 빈 칸들 (이전 달의 마지막 주)
     for (let i = 0; i < firstDayOfWeek; i++) {
       days.push(
-        <View key={`empty-${i}`} style={styles.dayContainer}>
+        <View key={`empty-${year}-${month}-empty-${i}`} style={styles.dayContainer}>
           <Text style={styles.emptyDay}></Text>
         </View>,
       );
@@ -86,10 +89,18 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
       const hasCleaning = hasCleaningRollCall(date);
 
       days.push(
-        <TouchableOpacity key={day} style={styles.dayContainer} onPress={() => selectDate(day)}>
-          <View style={isTodayDay ? styles.todayContainer : undefined}>
-            <Text style={[styles.dayText, isTodayDay && styles.todayText]}>{day}</Text>
-          </View>
+        <TouchableOpacity
+          key={`${year}-${month}-${day}`}
+          style={styles.dayContainer}
+          onPress={() => selectDate(day)}
+        >
+          {isTodayDay ? (
+            <View style={styles.todayContainer}>
+              <Text style={[styles.dayText, styles.todayText]}>{day}</Text>
+            </View>
+          ) : (
+            <Text style={styles.dayText}>{day}</Text>
+          )}
           {hasRegular && !hasCleaning && <View style={styles.regularRollCallDot} />}
           {hasCleaning && <View style={styles.cleaningRollCallDot} />}
         </TouchableOpacity>,


### PR DESCRIPTION
캘린더 위젯에서 오늘 날짜가 아님에도 오늘 날짜를 표기하는 문제와 오늘 날짜가 2개가 표시되는 문제를 해결하였습니다.
(이전)
<img width="590" height="1278" alt="KakaoTalk_20250917_140728109" src="https://github.com/user-attachments/assets/436fcb82-6b98-44aa-88c7-b432e0827cc4" />
<img width="590" height="1278" alt="KakaoTalk_20250917_140728109_01" src="https://github.com/user-attachments/assets/38fff214-6f2e-4c69-845c-459bd5fe4f2c" />

(이후)
<img width="590" height="1278" alt="KakaoTalk_20250917_140858446" src="https://github.com/user-attachments/assets/c5b21e71-8dbc-42c3-bd8a-d8175daffdcb" />
<img width="590" height="1278" alt="KakaoTalk_20250917_140858446_01" src="https://github.com/user-attachments/assets/aa2ae6a8-684f-4dc5-a60e-f3937baef507" />
