### PR TITLE
feat: 캘린더 위젯 API 연동 및 UI 개선

### DIFF
--- a/components/CalendarWidget.tsx
+++ b/components/CalendarWidget.tsx
@@ -110,9 +110,11 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
           ) : (
             <Text style={styles.dayText}>{day}</Text>
           )}
-          {hasRegular && !hasCleaning && <View style={styles.regularRollCallDot} />}
-          {hasCleaning && <View style={styles.cleaningRollCallDot} />}
-          {hasPaymentEvent && !hasRegular && !hasCleaning && <View style={styles.paymentDot} />}
+          <View style={styles.dotsRow}>
+            {hasRegular && <View style={[styles.dotBase, styles.dotRegular]} />}
+            {hasCleaning && <View style={[styles.dotBase, styles.dotCleaning]} />}
+            {hasPaymentEvent && <View style={[styles.dotBase, styles.dotPayment]} />}
+          </View>
         </TouchableOpacity>,
       );
     }
@@ -321,36 +323,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   regularRollCallDot: {
-    position: 'absolute',
-    bottom: 2, // bottom: -6에서 2로 변경하여 컨테이너 내부에 위치
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: '#FFD700',
-    shadowColor: '#FFD700',
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
-    shadowOpacity: 0.3,
-    shadowRadius: 2,
-    elevation: 2,
+    display: 'none',
   },
   cleaningRollCallDot: {
-    position: 'absolute',
-    bottom: 2, // bottom: -6에서 2로 변경하여 컨테이너 내부에 위치
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: '#007AFF',
-    shadowColor: '#007AFF',
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
-    shadowOpacity: 0.3,
-    shadowRadius: 2,
-    elevation: 2,
+    display: 'none',
   },
   legend: {
     marginTop: 8,
@@ -396,20 +372,34 @@ const styles = StyleSheet.create({
     color: '#007AFF',
   },
   paymentDot: {
+    display: 'none',
+  },
+  dotsRow: {
     position: 'absolute',
     bottom: 2,
+    flexDirection: 'row',
+    gap: 2,
+  },
+  dotBase: {
     width: 6,
     height: 6,
     borderRadius: 3,
-    backgroundColor: '#34C759',
-    shadowColor: '#34C759',
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
+    shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.3,
     shadowRadius: 2,
     elevation: 2,
+  },
+  dotRegular: {
+    backgroundColor: '#FFD700',
+    shadowColor: '#FFD700',
+  },
+  dotCleaning: {
+    backgroundColor: '#007AFF',
+    shadowColor: '#007AFF',
+  },
+  dotPayment: {
+    backgroundColor: '#34C759',
+    shadowColor: '#34C759',
   },
   legendPaymentDot: {
     width: 8,

--- a/components/CalendarWidget.tsx
+++ b/components/CalendarWidget.tsx
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.02)',
   },
   weekDayContainer: {
-    flex: 1,
+    width: '14.28%',
     alignItems: 'center',
   },
   weekDayText: {
@@ -280,7 +280,7 @@ const styles = StyleSheet.create({
   calendarGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    paddingHorizontal: 8,
+    paddingHorizontal: 16,
     paddingVertical: 8,
     height: 280, // 더 많은 공간 확보
   },

--- a/docs/API.md
+++ b/docs/API.md
@@ -102,3 +102,44 @@ json
 
 { "error": "Notice ID is required." }
 { "error": "Notice not found" }
+
+캘린더 API
+
+1. 일정 조회
+
+- path: /calendar
+- 기능: 전체 또는 특정 날짜의 일정 조회
+- request
+  - 쿼리 파라미터: date (선택)
+  - 예: /calendar (전체)
+  - 예: /calendar?date=2025-09-20 (2025년 9월 20일의 일정을 조회)
+- method: GET
+- 전체 일정 response
+
+[
+{
+"id": 2,
+"date": "2025-09-19",
+"rollCallType": null,
+"paymentType": "가스"
+},
+{
+"id": 6,
+"date": "2025-09-29",
+"rollCallType": "일반",
+"paymentType": "수도"
+}
+]
+
+- date 파라미터 사용 response
+
+[
+{
+"id": 2,
+"date": "2025-09-19",
+"rollCallType": null,
+"paymentType": "가스"
+}
+]
+
+물론 하루에 일정이 두 개일 경우도 존재한다.

--- a/hooks/useCalendar.ts
+++ b/hooks/useCalendar.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getCalendarEvents } from '../services/apiService';
+import { CalendarEvent } from '../types/calendar';
+
+// 로컬 날짜를 YYYY-MM-DD 형식으로 변환하는 함수
+const formatDateToYYYYMMDD = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export function useCalendar() {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 전체 일정 로드
+  const loadAllEvents = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const allEvents = await getCalendarEvents();
+      setEvents(allEvents);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '캘린더 일정을 불러오는데 실패했습니다.';
+      setError(errorMessage);
+      console.error('Error loading calendar events:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // 특정 날짜의 일정 로드
+  const loadEventsByDate = useCallback(async (date: string) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const dateEvents = await getCalendarEvents(date);
+      setEvents(dateEvents);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '해당 날짜의 일정을 불러오는데 실패했습니다.';
+      setError(errorMessage);
+      console.error('Error loading calendar events by date:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // 특정 날짜에 일정이 있는지 확인
+  const hasEventOnDate = useCallback(
+    (date: Date): boolean => {
+      const dateString = formatDateToYYYYMMDD(date); // YYYY-MM-DD 형식
+      return events.some((event) => event.date === dateString);
+    },
+    [events],
+  );
+
+  // 특정 날짜의 일정 정보 가져오기
+  const getEventsOnDate = useCallback(
+    (date: Date): CalendarEvent[] => {
+      const dateString = formatDateToYYYYMMDD(date); // YYYY-MM-DD 형식
+      return events.filter((event) => event.date === dateString);
+    },
+    [events],
+  );
+
+  // 특정 날짜에 점호가 있는지 확인
+  const hasRollCallOnDate = useCallback(
+    (date: Date): boolean => {
+      const dateEvents = getEventsOnDate(date);
+      return dateEvents.some((event) => event.rollCallType !== null);
+    },
+    [getEventsOnDate],
+  );
+
+  // 특정 날짜에 관비 납부 마감이 있는지 확인
+  const hasPaymentOnDate = useCallback(
+    (date: Date): boolean => {
+      const dateEvents = getEventsOnDate(date);
+      return dateEvents.some((event) => event.paymentType !== null);
+    },
+    [getEventsOnDate],
+  );
+
+  // 특정 날짜의 점호 타입 가져오기
+  const getRollCallTypeOnDate = useCallback(
+    (date: Date): string | null => {
+      const dateEvents = getEventsOnDate(date);
+      const rollCallEvent = dateEvents.find((event) => event.rollCallType !== null);
+      return rollCallEvent?.rollCallType || null;
+    },
+    [getEventsOnDate],
+  );
+
+  // 특정 날짜의 관비 납부 마감 타입 가져오기
+  const getPaymentTypeOnDate = useCallback(
+    (date: Date): string | null => {
+      const dateEvents = getEventsOnDate(date);
+      const paymentEvent = dateEvents.find((event) => event.paymentType !== null);
+      return paymentEvent?.paymentType || null;
+    },
+    [getEventsOnDate],
+  );
+
+  // 초기 로드
+  useEffect(() => {
+    loadAllEvents();
+  }, [loadAllEvents]);
+
+  return {
+    events,
+    isLoading,
+    error,
+    loadAllEvents,
+    loadEventsByDate,
+    hasEventOnDate,
+    getEventsOnDate,
+    hasRollCallOnDate,
+    hasPaymentOnDate,
+    getRollCallTypeOnDate,
+    getPaymentTypeOnDate,
+  } as const;
+}

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,4 +1,5 @@
 import { Notice, NoticesResponse, PageInfo } from '../types/notice';
+import { CalendarEvent, CalendarResponse } from '../types/calendar';
 
 const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL as string;
 
@@ -70,5 +71,31 @@ export const getNoticeById = async (id: number): Promise<Notice | null> => {
   } catch (error) {
     console.error('Error in getNoticeById function:', error);
     return null;
+  }
+};
+
+// 캘린더 일정 조회 (전체 또는 특정 날짜)
+export const getCalendarEvents = async (date?: string): Promise<CalendarResponse> => {
+  try {
+    const url = date ? `${BASE_URL}/calendar?date=${date}` : `${BASE_URL}/calendar`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error('Calendar API Error Response:', {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorBody,
+      });
+      throw new Error(`Failed to fetch calendar events with status: ${response.status}`);
+    }
+
+    const result = (await response.json()) as CalendarResponse;
+    console.log('Received calendar events from API:', result);
+
+    return result;
+  } catch (error) {
+    console.error('Error in getCalendarEvents function:', error);
+    return [];
   }
 };

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -1,0 +1,8 @@
+export interface CalendarEvent {
+  id: number;
+  date: string; // YYYY-MM-DD 형식
+  rollCallType: string | null; // "일반" 또는 null
+  paymentType: string | null; // "가스", "수도" 등
+}
+
+export interface CalendarResponse extends Array<CalendarEvent> {}


### PR DESCRIPTION
기존 목업 데이터를 제거하고 실제 캘린더 API(/calendar)와 연동하여 일정 데이터를 동적으로 로드하도록 하였습니다.
날짜 처리 오류 수정: UTC 변환으로 인한 날짜 밀림 현상을 해결하여 API 응답 날짜와 정확히 일치하도록 개선하였습니다.
요일 헤더와 날짜 그리드의 열 정렬 문제 해결 및 하루에 여러 일정이 있을 때 점을 가로로 나란히 표시하도록 UI를 개선하였습니다.

<img width="590" height="1278" alt="KakaoTalk_20250921_111730347" src="https://github.com/user-attachments/assets/14c23ef8-c607-4cb0-8945-937fdc810335" />
