### PR TITLE
fix: 캘린더 ui 버그 수정 및 하단 바 디자인 수정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -53,10 +53,6 @@ export default function TabLayout() {
         accessibilityRole="tablist"
         style={{
           backgroundColor: 'rgba(255,255,255,0.97)',
-          borderTopWidth: 1,
-          borderTopColor: 'rgba(0,0,0,0.08)',
-          // 바를 화면에서 아주 조금 아래로 내리기 위해 상단 마진 추가
-          marginTop: 4,
           // 콘텐츠를 위로 붙이기 위해 상단 패딩을 줄이고 하단 패딩을 늘림
           paddingTop: 6,
           paddingBottom: Math.max(14, insets.bottom),

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,7 +12,7 @@ export default function HomeScreen() {
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 10 }]}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom }]}
       showsVerticalScrollIndicator={false}
     >
       <ThemedView style={[styles.content, { paddingTop: insets.top + 20 }]}>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -10,7 +10,7 @@ export default function SettingsScreen() {
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 10 }]}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom }]}
       showsVerticalScrollIndicator={false}
     >
       <ThemedView style={[styles.content, { paddingTop: insets.top + 20 }]}>

--- a/components/CalendarWidget.tsx
+++ b/components/CalendarWidget.tsx
@@ -141,49 +141,51 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
 
   return (
     <ThemedView style={styles.container}>
-      <View style={styles.header}>
-        <TouchableOpacity onPress={goToPreviousMonth} style={styles.navButton}>
-          <Text style={styles.navButtonText}>‹</Text>
-        </TouchableOpacity>
+      <View style={styles.cardBody}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={goToPreviousMonth} style={styles.navButton}>
+            <Text style={styles.navButtonText}>‹</Text>
+          </TouchableOpacity>
 
-        <ThemedText style={styles.monthYear}>
-          {year}년 {monthNames[month]}
-        </ThemedText>
+          <ThemedText style={styles.monthYear}>
+            {year}년 {monthNames[month]}
+          </ThemedText>
 
-        <TouchableOpacity onPress={goToNextMonth} style={styles.navButton}>
-          <Text style={styles.navButtonText}>›</Text>
-        </TouchableOpacity>
-      </View>
+          <TouchableOpacity onPress={goToNextMonth} style={styles.navButton}>
+            <Text style={styles.navButtonText}>›</Text>
+          </TouchableOpacity>
+        </View>
 
-      <View style={styles.weekDaysContainer}>
-        {weekDays.map((day, index) => (
-          <View key={day} style={styles.weekDayContainer}>
-            <Text
-              style={[
-                styles.weekDayText,
-                index === 0 && styles.sundayText,
-                index === 1 && styles.mondayText,
-              ]}
-            >
-              {day}
-            </Text>
+        <View style={styles.weekDaysContainer}>
+          {weekDays.map((day, index) => (
+            <View key={day} style={styles.weekDayContainer}>
+              <Text
+                style={[
+                  styles.weekDayText,
+                  index === 0 && styles.sundayText,
+                  index === 6 && styles.saturdayText,
+                ]}
+              >
+                {day}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {isLoading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color="#007AFF" />
+            <Text style={styles.loadingText}>일정을 불러오는 중...</Text>
           </View>
-        ))}
+        ) : error ? (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>일정을 불러올 수 없습니다</Text>
+            <Text style={styles.errorSubText}>{error}</Text>
+          </View>
+        ) : (
+          <View style={styles.calendarGrid}>{renderCalendarDays()}</View>
+        )}
       </View>
-
-      {isLoading ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color="#007AFF" />
-          <Text style={styles.loadingText}>일정을 불러오는 중...</Text>
-        </View>
-      ) : error ? (
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorText}>일정을 불러올 수 없습니다</Text>
-          <Text style={styles.errorSubText}>{error}</Text>
-        </View>
-      ) : (
-        <View style={styles.calendarGrid}>{renderCalendarDays()}</View>
-      )}
 
       <View style={styles.legend}>
         <View style={styles.legendContainer}>
@@ -208,7 +210,8 @@ export default function CalendarWidget({ onDateSelect }: CalendarWidgetProps) {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: 16,
-    marginVertical: 8,
+    marginTop: 8,
+    marginBottom: 15,
     borderRadius: 20,
     backgroundColor: 'rgba(255,255,255,0.95)',
     shadowColor: '#000',
@@ -220,7 +223,12 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
     elevation: 4,
     overflow: 'hidden',
-    height: 460, // 범례를 포함한 전체 높이로 조정
+  },
+  cardBody: {
+    backgroundColor: 'rgba(255,255,255,0.95)',
+    paddingBottom: 0,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
   },
   header: {
     flexDirection: 'row',
@@ -275,7 +283,7 @@ const styles = StyleSheet.create({
   sundayText: {
     color: '#FF3B30',
   },
-  mondayText: {
+  saturdayText: {
     color: '#007AFF',
     fontWeight: '700',
   },
@@ -329,11 +337,14 @@ const styles = StyleSheet.create({
     display: 'none',
   },
   legend: {
-    marginTop: 8,
+    flex: 1,
+    marginTop: 0,
     paddingVertical: 12,
     paddingHorizontal: 20,
     backgroundColor: 'rgba(0,0,0,0.02)',
     alignItems: 'center',
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
   },
   legendContainer: {
     flexDirection: 'row',
@@ -414,7 +425,7 @@ const styles = StyleSheet.create({
     color: '#34C759',
   },
   loadingContainer: {
-    flex: 1,
+    height: 280,
     justifyContent: 'center',
     alignItems: 'center',
     paddingVertical: 40,
@@ -426,7 +437,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   errorContainer: {
-    flex: 1,
+    height: 280,
     justifyContent: 'center',
     alignItems: 'center',
     paddingVertical: 40,

--- a/components/MaintenancePayment.tsx
+++ b/components/MaintenancePayment.tsx
@@ -118,7 +118,8 @@ export default function MaintenancePayment() {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: 16,
-    marginVertical: 8,
+    marginTop: 0,
+    marginBottom: 8,
   },
   header: {
     flexDirection: 'row',

--- a/components/NoticeSection.tsx
+++ b/components/NoticeSection.tsx
@@ -99,7 +99,8 @@ export default function NoticeSection() {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: 16,
-    marginVertical: 8,
+    marginTop: 0,
+    marginBottom: 8,
   },
   header: {
     flexDirection: 'row',


### PR DESCRIPTION
요일 색상 수정: 토요일을 파란색으로, 월요일을 기본 회색으로 변경하였습니다.
범례 영역 레이아웃 안정화: 달 이동 시 범례가 흔들리지 않도록 로딩/에러 상태 높이를 통일하였습니다.
하단 여백 제거: 범례 배경이 카드 하단까지 꽉 차도록 구조 개선 및 색상을 통일하였습니다.
하단바 UI 정리: 탭바 위 회색 선과 여백 제거로 깔끔한 하단 영역을 구현하였습니다.

**(이전)**
<img width="590" height="1278" alt="KakaoTalk_20250924_151905459" src="https://github.com/user-attachments/assets/7664138e-d49d-40b9-b3d8-e1c73eb6c2f4" />
<img width="590" height="1278" alt="KakaoTalk_20250924_151905459_01" src="https://github.com/user-attachments/assets/fbb746ed-b2a8-4c1d-8a36-eeb46254ac67" />

**(이후)**
<img width="590" height="1278" alt="KakaoTalk_20250924_165943388" src="https://github.com/user-attachments/assets/ff9c7bd9-b8d9-446a-972a-9d95480213c6" />
<img width="590" height="1278" alt="KakaoTalk_20250924_165943388_01" src="https://github.com/user-attachments/assets/aea297b6-db46-4a2c-a129-52a55350f57c" />
